### PR TITLE
Reformat recipe card

### DIFF
--- a/cookbook-api/server/GraphQLSchema.ts
+++ b/cookbook-api/server/GraphQLSchema.ts
@@ -50,7 +50,7 @@ const createSchema = () => {
             recipes: {
                 type: new GraphQLList(RecipeType),
                 resolve: async (root, args) => {
-                    return await Recipe.findAll();
+                    return await Recipe.findAll({include: [User]});
                 }
             },
             googleClientId: {

--- a/cookbook-api/server/Server.ts
+++ b/cookbook-api/server/Server.ts
@@ -33,7 +33,7 @@ app.use(
   graphqlHTTP(request => ({
     schema: schema,
     rootValue: request,
-    graphiql: false,
+    graphiql: true,
   })),
 );
 

--- a/cookbook-front-end/src/App.tsx
+++ b/cookbook-front-end/src/App.tsx
@@ -49,6 +49,10 @@ const useStyles = makeStyles({
   },
   addButton: {
 
+  },
+  routerLink: {
+    textDecoration: "none",
+    color: "inherit"
   }
 });
 
@@ -80,7 +84,7 @@ const App = () => {
             className={classes.menuButton} 
             color="inherit" 
             aria-label="home">
-            <Link to="/">
+            <Link to="/" className={classes.routerLink}>
               <HomeIcon />
             </Link>
           </IconButton>
@@ -95,7 +99,7 @@ const App = () => {
               className={classes.addButton} 
               color="inherit" 
               aria-label="add">
-              <Link to="/create">
+              <Link to="/create" className={classes.routerLink}> 
                 <AddIcon />
               </Link>
             </IconButton>}

--- a/cookbook-front-end/src/Components/Recipes.tsx
+++ b/cookbook-front-end/src/Components/Recipes.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
-import {Card, CardHeader, CardActions, CircularProgress, CardMedia} from '@material-ui/core';
+import {Card, CardHeader, CardActions, CircularProgress, CardMedia, GridList, GridListTile, ListSubheader, GridListTileBar, IconButton} from '@material-ui/core';
 import { useQuery } from '@apollo/react-hooks';
 import gql from 'graphql-tag';
 import Error from './Error';
@@ -10,18 +10,28 @@ import Error from './Error';
 const useStyles = makeStyles((theme) => ({
     recipesRoot: {
     },
-    cardRoot: {
-        marginTop: theme.spacing(2),
-        display: "flex",
+    root: {
+        display: 'flex',
+        flexWrap: 'wrap',
+        justifyContent: 'space-around',
+        overflow: 'hidden',
+        backgroundColor: theme.palette.background.paper,
+        marginTop: theme.spacing(2)
+    },
+    gridList: {
+        width: "100%"
+    },
+    cardLink: {
+        textDecoration: "none"
+    },
+    tile: {
+        height: 400,
+        width: 400,
         padding: theme.spacing(2)
     },
-    cardTitle: {
-        flexGrow: 1
-    },
-    media: {
-        height: 100,
-        width: 100,
-        borderRadius: 10
+    image: {
+        width: "100%",
+        maxHeight: "100%"
     }
 }));
 
@@ -30,7 +40,11 @@ query Recipes{
     recipes {
         recipeId,
         name,
-        imageUrl
+        imageUrl,
+        creator {
+            firstName,
+            lastName
+        }
     }
 }
 `;
@@ -48,24 +62,20 @@ const Recipes = () => {
   }
 
   return <>
-        <div className={classes.recipesRoot}>
-          {data.recipes.map((r: any) => {
-              return <Card className = {classes.cardRoot} key={r.recipeId}>
-                  <CardHeader title={r.name} className={classes.cardTitle}/>
-                  <CardActions>
-                      <Link to={`recipes/${r.recipeId}`}>View recipe</Link>
-                  </CardActions>
-                  {
-                      r.imageUrl 
-                      &&
-                      <CardMedia
-                        className={classes.media}
-                        image={r.imageUrl}
-                        title={r.name}/>
-                  }
-              </Card>
-          })}
-        </div>
+    <div className={classes.root}>
+        <GridList cols={3} spacing={4} className={classes.gridList}>
+            {data.recipes.map((r: any) => (
+                <GridListTile cols={1} className={classes.tile}>
+                    <Link to={`recipes/${r.recipeId}`} className={classes.cardLink} key={r.recipeId}>
+                        <img src={r.imageUrl} alt={r.name} className={classes.image}/>
+                        <GridListTileBar
+                            title={r.name}
+                            subtitle={<span>by: {r.creator.firstName} {r.creator.lastName}</span>}/>
+                    </Link>
+                </GridListTile>
+            ))}
+        </GridList>
+    </div>
     </>;
 }
 

--- a/cookbook-front-end/src/Components/Recipes.tsx
+++ b/cookbook-front-end/src/Components/Recipes.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
-import {Card, CardHeader, CardActions, CircularProgress, CardMedia, GridList, GridListTile, ListSubheader, GridListTileBar, IconButton} from '@material-ui/core';
+import {CircularProgress, GridList, GridListTile, GridListTileBar} from '@material-ui/core';
 import { useQuery } from '@apollo/react-hooks';
 import gql from 'graphql-tag';
 import Error from './Error';

--- a/cookbook-front-end/src/Components/Recipes.tsx
+++ b/cookbook-front-end/src/Components/Recipes.tsx
@@ -5,6 +5,7 @@ import {Card, CardHeader, CardActions, CircularProgress, CardMedia, GridList, Gr
 import { useQuery } from '@apollo/react-hooks';
 import gql from 'graphql-tag';
 import Error from './Error';
+import OutdoorGrillIcon from '@material-ui/icons/OutdoorGrill';
 
 
 const useStyles = makeStyles((theme) => ({
@@ -32,6 +33,14 @@ const useStyles = makeStyles((theme) => ({
     image: {
         width: "100%",
         maxHeight: "100%"
+    },
+    iconImage: {
+        width: 150,
+        height: 150,
+        color: theme.palette.grey[700]
+    },
+    imageWrapper: {
+        textAlign: "center"
     }
 }));
 
@@ -67,7 +76,13 @@ const Recipes = () => {
             {data.recipes.map((r: any) => (
                 <GridListTile cols={1} className={classes.tile}>
                     <Link to={`recipes/${r.recipeId}`} className={classes.cardLink} key={r.recipeId}>
-                        <img src={r.imageUrl} alt={r.name} className={classes.image}/>
+                        <div className={classes.imageWrapper}>
+                        {
+                            !!r.imageUrl
+                            ? <img src={r.imageUrl} alt={r.name} className={classes.image}/>
+                            : <OutdoorGrillIcon className={classes.iconImage}/>
+                        }
+                        </div>
                         <GridListTileBar
                             title={r.name}
                             subtitle={<span>by: {r.creator.firstName} {r.creator.lastName}</span>}/>


### PR DESCRIPTION
make the recipes cards way prettier and directly clickable. incorporate the image in a significantly better way.

To do this, I used the gridlist and gridtile components instead of using "Cards".

![image](https://user-images.githubusercontent.com/4572207/83953581-44c5a200-a80f-11ea-997c-da1b0e4dd6ce.png)
